### PR TITLE
Add support to cab_package for non-English system locales

### DIFF
--- a/lib/chef/provider/package/cab.rb
+++ b/lib/chef/provider/package/cab.rb
@@ -45,7 +45,7 @@ class Chef
         end
 
         def dism_command(command)
-          shellout = Mixlib::ShellOut.new("dism.exe /Online #{command} /NoRestart", { :timeout => @new_resource.timeout })
+          shellout = Mixlib::ShellOut.new("dism.exe /Online /English #{command} /NoRestart", { :timeout => @new_resource.timeout })
           with_os_architecture(nil) do
             shellout.run_command
           end


### PR DESCRIPTION
### Description

Support for running cap_package on non-English system locales

When using cap_package on Windows with non-English system locales, such as Russian, chef-client throws up an error:

> undefined method `[]' for nil:NilClass

The reason is that dism.exe output is in russian language and therefore cannot be parsed.

This PR ensures that output of dism.exe will always be in English.